### PR TITLE
Similarity threshold

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.1</version>
+    <version>3.4.3</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>co.elastic.clients</groupId>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>org.springframework.ai</groupId>
         <artifactId>spring-ai-bom</artifactId>
-        <version>1.0.0-M3</version>
+        <version>1.0.0-M6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -42,24 +42,24 @@
     <dependency>
       <groupId>org.springframework.ai</groupId>
       <artifactId>spring-ai-spring-boot-autoconfigure</artifactId>
-      <version>1.0.0-SNAPSHOT</version>
+      <version>1.0.0-M6</version>
     </dependency>
 
     <dependency>
       <groupId>org.springframework.ai</groupId>
       <artifactId>spring-ai-elasticsearch-store</artifactId>
-      <version>1.0.0-SNAPSHOT</version>
+      <version>1.0.0-M6</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.ai</groupId>
       <artifactId>spring-ai-pdf-document-reader</artifactId>
-      <version>1.0.0-SNAPSHOT</version>
+      <version>1.0.0-M6</version>
     </dependency>
 
     <dependency>
       <groupId>org.springframework.ai</groupId>
       <artifactId>spring-ai-openai</artifactId>
-      <version>1.0.0-SNAPSHOT</version>
+      <version>1.0.0-M6</version>
     </dependency>
 
     <!-- dependency added to solve to following error:-->
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-websocket</artifactId>
-      <version>3.3.1</version>
+      <version>3.4.3</version>
     </dependency>
 
   </dependencies>

--- a/src/main/java/demo/elastic/rag/RagService.java
+++ b/src/main/java/demo/elastic/rag/RagService.java
@@ -40,7 +40,7 @@ public class RagService {
         // Querying the vector store for documents related to the question
         List<Document> vectorStoreResult =
             vectorStore.doSimilaritySearch(SearchRequest.builder().query(question).topK(5)
-                    .similarityThreshold(0.0).build());
+                    .similarityThreshold(0.6).build());
 
         // Merging the documents into a single string
         String documents = vectorStoreResult.stream()

--- a/src/main/java/demo/elastic/rag/RagService.java
+++ b/src/main/java/demo/elastic/rag/RagService.java
@@ -4,7 +4,7 @@ import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.reader.pdf.PagePdfDocumentReader;
 import org.springframework.ai.transformer.splitter.TokenTextSplitter;
-import org.springframework.ai.vectorstore.ElasticsearchVectorStore;
+import org.springframework.ai.vectorstore.elasticsearch.ElasticsearchVectorStore;
 import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.stereotype.Service;
 
@@ -39,11 +39,12 @@ public class RagService {
 
         // Querying the vector store for documents related to the question
         List<Document> vectorStoreResult =
-            vectorStore.doSimilaritySearch(SearchRequest.query(question).withTopK(5).withSimilarityThreshold(0.0));
+            vectorStore.doSimilaritySearch(SearchRequest.builder().query(question).topK(5)
+                    .similarityThreshold(0.0).build());
 
         // Merging the documents into a single string
         String documents = vectorStoreResult.stream()
-            .map(Document::getContent)
+            .map(Document::getText)
             .collect(Collectors.joining(System.lineSeparator()));
 
         // Setting the prompt with the context


### PR DESCRIPTION
I think that the similarity threshold behaves the other way around than it is described in the blog post: 1.0 would only accept exact matches (and 0.0 accepts anything). I'm not sure if 0.6 is a great value but with a couple of queries I normally demo it still seemed to work; while 0.8 for example was too selective.

https://docs.spring.io/spring-ai/docs/current/api/org/springframework/ai/vectorstore/SearchRequest.html#withSimilarityThreshold(double)